### PR TITLE
fix grid_base.is_inside_rect() logical

### DIFF
--- a/inventory/scripts/grid_base.gd
+++ b/inventory/scripts/grid_base.gd
@@ -245,7 +245,7 @@ func area_is_clear(zone: Rect2, execlude: Array) -> bool:
 ##Checks if the given zone if fully inside
 func is_inside_rect(zone: Rect2) -> bool:
 	# if the top left and the bottom right corners are inside the zone, then it's valid otherwise it's not valid
-	if not get_global_rect().has_point(zone.position + Vector2(1, 1)) or not get_global_rect().has_point(zone.end - Vector2(1,1)):
+	if not get_global_rect().has_point(zone.position) or not get_global_rect().has_point(zone.end - Vector2(1,1)):
 		return false
 	return true
 


### PR DESCRIPTION
> By convention, points on the right and bottom edges are not included.

Hi @Hexadotz, According to [classes/class_rect2.html](https://docs.godotengine.org/en/4.3/classes/class_rect2.html#class-rect2-method-has-point), only points on right and button edge needs -Vector2(1, 1) operation.